### PR TITLE
Improve performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test-browser:
 
 test-ci: test-node
 	@NODE_ENV=test $(BIN)/karma start karma.conf-ci.js --single-run
-	@make benchmark
+	@make benchmark-ci
 
 test-browser-watch:
 	@NODE_ENV=test $(BIN)/karma start

--- a/karma.benchmark.conf-ci.js
+++ b/karma.benchmark.conf-ci.js
@@ -77,6 +77,7 @@ module.exports = function (config) {
     sauceLabs: {
       testName: 'driftwood'
     },
+    browserNoActivityTimeout: 60000,
     customLaunchers: customLaunchers,
     browsers: Object.keys(customLaunchers),
     reporters: ['benchmark', 'saucelabs']


### PR DESCRIPTION
@roberttod 

Main change here is moving all the name and level checking to when the logger is instantiated, rather than at log time. Individual log levels can be stubbed out with a noop.