### PR TITLE
Guard JSON.parse from empty strings

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -6,7 +6,7 @@ var DEFAULT_LEVEL = 'info'
 function get () {
   try {
     var payload = storage.get()
-    return JSON.parse(payload) || {}
+    return payload && JSON.parse(payload) || {}
   } catch (e) {
     return {}
   }


### PR DESCRIPTION
> [MoneyCorp] has overwritten `JSON.parse` to have a try/catch in it which sends off an error ping for them if something fails. often `payload` is just a blank string, so this causes their logs to fill up.